### PR TITLE
Fixes Error with maven lifecycle mapping under eclipse w/ m2e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
                         <groupId>com.lewisd</groupId>
                         <artifactId>lint-maven-plugin</artifactId>
                         <versionRange>[0.0.11,)</versionRange>
+                        <goal>check</goal>
                       </pluginExecutionFilter>
                       <action>
                         <ignore/>


### PR DESCRIPTION
See https://github.com/deeplearning4j/deeplearning4j/issues/3625

Tested on eclipse mars onwards.