### PR TITLE
Introduces an optional profile for removing prior artifact versions of the project - essential to keep CI local repos trim - useful for developers (esp. if reliant on mirrors)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,32 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+          <id>trimSnapshots</id>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                  <execution>
+                    <id>remove-old-artifacts</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>remove-project-artifact</goal>
+                    </goals>
+                    <configuration>
+                      <removeAll>true</removeAll>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
+        </profile>
+
     </profiles>
 
     <reporting>


### PR DESCRIPTION
- essential to keep CI local repos trim
- useful for developers (esp. if reliant on mirrors)

(initially meant to trigger auto-builds, but that will happen later)